### PR TITLE
Work related to the non-commutativeness of composing rotations and convolutional layers

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     # Gets the model and the conv part of model, the function also trains the
     # network, if there doesn't exist a saved network
     model = train_network(get_model(x_test), options)
-    only_convolutional = split_network(model, options.convlayers)
+    only_convolutional, _ = split_network(model, options.convlayers)
     training_samples = get_training_samples(
         only_convolutional, x_train, y_train, options)
 

--- a/pylintrc
+++ b/pylintrc
@@ -146,6 +146,7 @@ disable=print-statement,
         no-name-in-module,
         exec-used,
         too-many-statements,
+        too-many-branches
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/serial_main.py
+++ b/serial_main.py
@@ -77,6 +77,11 @@ def setup():
         action='store_false',
         help='Skip the convolution experiment')
     parser.add_argument(
+        '--norot',
+        dest='rot_first',
+        action='store_false',
+        help='Skip the rotate first experiment')
+    parser.add_argument(
         '--iterations',
         type=int,
         default=501,
@@ -141,6 +146,24 @@ def setup():
             cProfile.run(cmd_string, profiling_dir + '/convolution1')
         else:
             exec(cmd_string)
+
+    if args.rot_first:
+        options = Options()
+        options.serial = True
+        options.convlayers = 8
+        options.step = 20
+        options.combine = False
+        options.representatives = False
+        options.rotate_first = True
+        options.post_init()
+        only_convolutional, _ = split_network(model, options.convlayers)
+        cmd_string = """run_experiment(args.iterations, options, x_train, y_train, x_test, y_test,
+                        model, only_convolutional, experiment_dir + '/rotate_first.csv')"""
+        if args.profile:
+            cProfile.run(cmd_string, profiling_dir + '/rotate_first')
+        else:
+            exec(cmd_string)
+
 
 
 if __name__ == "__main__":

--- a/serial_main.py
+++ b/serial_main.py
@@ -26,7 +26,7 @@ def run_experiment(iterations,
                    filename):
     with open(filename, 'w') as f:
         f.write("examples,time,accuracy\n")
-        for i in tqdm(range(10, iterations), desc=filename):
+        for i in tqdm(range(10, iterations, 20), desc=filename):
             options.examples = i
             start_time = perf_counter()
             training_samples = get_training_samples(
@@ -50,7 +50,7 @@ def setup():
     x_train, y_train, x_test, y_test = get_dataset(options)  # pylint: disable=unused-variable
 
     model = train_network(get_model(x_test), options)
-    only_convolutional = split_network(model, options.convlayers)  # pylint: disable=unused-variable
+    only_convolutional, _ = split_network(model, options.convlayers)  # pylint: disable=unused-variable
 
     profiling_dir = 'profiling'
     experiment_dir = 'experiments'
@@ -129,12 +129,12 @@ def setup():
     if args.conv:
         options = Options()
         options.serial = True
-        options.convlayers = 1
+        options.convlayers = 8
         options.step = 20
         options.combine = False
         options.representatives = False
         options.post_init()
-        only_convolutional = split_network(model, options.convlayers)
+        only_convolutional, _ = split_network(model, options.convlayers)
         cmd_string = """run_experiment(args.iterations, options, x_train, y_train, x_test, y_test,
                         model, only_convolutional, experiment_dir + '/convolution1.csv')"""
         if args.profile:

--- a/src/image_processor.py
+++ b/src/image_processor.py
@@ -14,9 +14,9 @@ def process_image(image, only_convolutional, options):
 
 def process_images(images, only_convolutional, options):
     if options.convlayers != 0:
+        if images.shape[-1] != 1:
+            images = tf.expand_dims(images, -1)
         images = only_convolutional.predict(images)
-    if options.combine and options.convlayers != 0:
-        print(images.shape)
     if options.enlarge:
         images = enlarge_images(images)
     return images

--- a/src/options.py
+++ b/src/options.py
@@ -24,6 +24,7 @@ class Options: # pylint: disable=too-many-instance-attributes
         self.serial = False
         self.representatives = False
         self.samples = 100
+        self.rotate_first = False
 
     def parse_args(self, xtest_len):
         parser = argparse.ArgumentParser(description='Identify some numbers')

--- a/src/rotation_finder.py
+++ b/src/rotation_finder.py
@@ -96,6 +96,8 @@ def get_best_rotation(training_samples, rotations, options):
     between m and n. It will then find the index i,j with the lowest error,
     returning j (The rotation)
     """
+    if rotations.shape[1:] != training_samples.shape[1:]:
+        raise ValueError("Incompatible shapes: {0} and {1}".format(rotations.shape, training_samples.shape))
 
     # Expand the dimensions of the vectors to be (1, n) + i
     # and (n, 1) + 1. This makes the arrays compatible using

--- a/src/rotation_finder.py
+++ b/src/rotation_finder.py
@@ -5,7 +5,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_addons as tfa
 
-from src.image_processor import process_image
+from src.image_processor import process_image, process_images
 from src.utils import combine_save_patches, rotate_images
 
 
@@ -35,8 +35,13 @@ def get_proper_rotation(only_convolutional,
                         imgindx,
                         options):
     """Get the rotation to apply to a network to make it recognizable"""
-    image = process_image(image, only_convolutional, options)
-    rotations = get_rotations(image, options)
+    rotations = None
+    if options.rotate_first:
+        rotations = get_rotations(image, options)
+        rotations = process_images(rotations, only_convolutional, options)
+    else:
+        image = process_image(image, only_convolutional, options)
+        rotations = get_rotations(image, options)
 
     if options.debug:
         for index, rotation in enumerate(rotations):

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,6 +1,6 @@
 from tqdm.auto import tqdm
 
-import numpy as np
+import tensorflow as tf
 from src.rotation_finder import get_proper_rotation
 from src.utils import rotate_image, combine_save_patches, random_rotation_angle
 
@@ -36,9 +36,9 @@ def check_some(only_convolutional, x_test, y_test, model, examples, options):
               str(back_rotation_total / options.samples))
 
     y_to_test = y_test[:options.samples]
-    to_test = np.array(to_test, 'float32')
+    to_test = tf.cast(to_test, tf.float32)
     verbose = 2
     if options.serial:
         verbose = 0
-    return model.evaluate(np.expand_dims(to_test, -1),
+    return model.evaluate(tf.expand_dims(to_test, -1),
                           y_to_test, verbose=verbose)

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,42 @@
+import math
+import unittest
+import tensorflow as tf
+import tensorflow_addons as tfa
+
+from src.network import train_network, get_dataset, get_model, split_network
+from src.options import Options
+
+
+class TestSplitter(unittest.TestCase):
+    """Test the network splitting function"""
+    def test_split(self):
+        options = Options()
+        _, _, x_test, _ = get_dataset(options)
+        model = train_network(get_model(x_test), options)
+        part1, part2 = split_network(model, 3)
+        x_test = tf.expand_dims(x_test, -1)
+        model_output = model(x_test[0:5])
+        split_output = part2(part1(x_test[0:5]))
+
+        equality = tf.math.reduce_all(tf.equal(model_output, split_output))
+        self.assertEqual(equality, True)
+
+
+    def test_compose_rotation(self):
+        """Test whether rotation -> convolution == convolution -> rotation
+        It isn't. This has implications for our project.
+        This is not as much a test as a demonstration of fact"""
+        options = Options()
+        _, _, x_test, _ = get_dataset(options)
+        model = train_network(get_model(x_test), options)
+        part1, _ = split_network(model, 8)
+        image = tf.expand_dims(tf.expand_dims(x_test[0], -1), 0)
+        rotated_image = tfa.image.rotate(image, math.pi)
+        out = tfa.image.rotate(part1(image), math.pi)
+        rotated_out = part1(rotated_image)
+        equality = tf.math.reduce_all(tf.equal(tfa.image.rotate(out, math.pi), rotated_out))
+        self.assertEqual(equality, False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a test which demonstrates that rotate(convolute(image)) != convolute(rotate(image)). It does this by modifying the `split_network` function to give out both ends of the network.

Additionally it adds a new experiment, which rotates the image before convoluting it.